### PR TITLE
Add Artifactory Publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ run/
 
 # images
 *.xcf
+
+# artifactory publishing
+private.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'fabric-loom' version '0.2.6-SNAPSHOT'
 	id 'maven-publish'
+	id "com.jfrog.artifactory" version "4.9.0"
 }
 
 repositories {
@@ -11,6 +12,10 @@ repositories {
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
+
+if(rootProject.file('private.gradle').exists()) { //Publishing details
+	apply from: 'private.gradle'
+}
 
 archivesBaseName = project.archives_base_name
 version = "${project.mod_version}+mc.${project.minecraft_version}"
@@ -75,11 +80,21 @@ jar {
 // configure the maven publication
 publishing {
 	publications {
-		mavenJava(MavenPublication) {
+		maven(MavenPublication) {
 			// add all the jars that should be included when publishing to maven
-			artifact(remapJar) {
+			//artifact(jar) {
+			//	builtBy remapJar
+			//}
+			artifact ("${project.buildDir.absolutePath}/libs/${archivesBaseName}-${project.version}.jar") { //release jar - file location not provided anywhere in loom
+				classifier null
 				builtBy remapJar
 			}
+
+			artifact ("${project.buildDir.absolutePath}/libs/${archivesBaseName}-${project.version}-dev.jar") { //release jar - file location not provided anywhere in loom
+				classifier "dev"
+				builtBy remapJar
+			}
+
 			artifact(sourcesJar) {
 				builtBy remapSourcesJar
 			}
@@ -90,5 +105,31 @@ publishing {
 	repositories {
 		// uncomment to publish to the local maven
 		// mavenLocal()
+	}
+}
+
+artifactory {
+	if (project.hasProperty("artifactoryUsername")) {
+		contextUrl = "http://server.bbkr.space:8081/artifactory/"
+		publish {
+			repository {
+				if (version.contains("SNAPSHOT")) {
+					repoKey = "libs-snapshot"
+				} else {
+					repoKey = "libs-release"
+				}
+
+				username = artifactoryUsername
+				password = artifactoryPassword
+			}
+			defaults {
+				publications("maven")
+
+				publishArtifacts = true
+				publishPom = true
+			}
+		}
+	} else {
+		println "Cannot configure artifactory; please define ext.artifactoryUsername and ext.artifactoryPassword before running artifactoryPublish"
 	}
 }


### PR DESCRIPTION
This PR sets up Banner++ to be published on the Cotton maven. Due to the sensitive nature of maven usernames/passwords, there are steps that need to be taken after this is merged:

1. contact me on Discord to create a user account
2. create a `private.gradle` file in the root project folder, with contents as described below
3. when building, use `./gradlew artifactoryPublish` instead of `./gradlew build`, as `artifactoryPublish` also runs build

The `private.gradle` should be set up as such:
```gradle
ext {
    artifactoryUsername = "<username>"
    artifactoryPassword = "<password>"
}
```

A version has [already been published](http://server.bbkr.space:8081/artifactory/libs-release/io/github/kvverti/bannerpp/) to test the functionality of this PR.