### PR TITLE
Abstract LoomPatternItem to an interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ Registry.register(LoomPatterns.REGISTRY, new Identifier("modid", "my_pattern"), 
 ```
 Normal patterns are those that don't need an item to be placed in the loom in order to select them, while special patterns do need such an item.
 
-Items associated with special patterns are instances of `LoomPatternItem`, the analogue of the vanilla `BannerPatternItem`. Simply register one of these items with each special pattern, and they will automatically be usable in the loom.
+To mark an Item as a pattern item in the Loom, implement the `LoomPatternProvider` interface on the item.
+The `LoomPatternItem` class is a convenience subclass of `Item` that implements this interface.
 
 ```java
 Registry.register(Registry.ITEM, new Identifier("modid", "my_pattern_item"), new LoomPatternItem(MY_PATTERN, itemSettings));
 ```
 
-## Resouce Keys
+## Resource Keys
 
 By default, Loom pattern textures are stored under `modid:textures/pattern/banner/my_pattern.png` and `modid:textures/pattern/shield/my_pattern.png`.
 

--- a/src/main/java/io/github/fablabsmc/fablabs/api/bannerpattern/v1/LoomPatternItem.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/bannerpattern/v1/LoomPatternItem.java
@@ -16,7 +16,7 @@ import net.minecraft.world.World;
 /**
  * The Banner++ equivalent of BannerPatternItem.
  */
-public class LoomPatternItem extends Item {
+public class LoomPatternItem extends Item implements LoomPatternProvider {
 	private final LoomPattern pattern;
 
 	public LoomPatternItem(LoomPattern pattern, Item.Settings settings) {
@@ -24,6 +24,7 @@ public class LoomPatternItem extends Item {
 		this.pattern = checkNotNull(pattern);
 	}
 
+	@Override
 	public final LoomPattern getPattern() {
 		return pattern;
 	}

--- a/src/main/java/io/github/fablabsmc/fablabs/api/bannerpattern/v1/LoomPatternProvider.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/bannerpattern/v1/LoomPatternProvider.java
@@ -1,0 +1,12 @@
+package io.github.fablabsmc.fablabs.api.bannerpattern.v1;
+
+/**
+ * Implement this on an Item to mark it as a pattern item
+ * @see io.github.fablabsmc.fablabs.api.bannerpattern.v1.LoomPatternItem for a convenience implementation.
+ */
+public interface LoomPatternProvider {
+    /**
+     * @return The pattern associated with this item. Must not be null.
+     */
+    LoomPattern getPattern();
+}

--- a/src/main/java/io/github/fablabsmc/fablabs/mixin/bannerpattern/LoomContainerMixin.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/mixin/bannerpattern/LoomContainerMixin.java
@@ -1,7 +1,7 @@
 package io.github.fablabsmc.fablabs.mixin.bannerpattern;
 
 import io.github.fablabsmc.fablabs.api.bannerpattern.v1.LoomPattern;
-import io.github.fablabsmc.fablabs.api.bannerpattern.v1.LoomPatternItem;
+import io.github.fablabsmc.fablabs.api.bannerpattern.v1.LoomPatternProvider;
 import io.github.fablabsmc.fablabs.api.bannerpattern.v1.LoomPatterns;
 import io.github.fablabsmc.fablabs.api.bannerpattern.v1.PatternLimitModifier;
 import io.github.fablabsmc.fablabs.impl.bannerpattern.LoomPatternsInternal;
@@ -164,11 +164,11 @@ public abstract class LoomContainerMixin extends ScreenHandler {
 		ItemStack patternStack = this.patternSlot.getStack();
 
 		// only run for special loom patterns
-		if (!patternStack.isEmpty() && patternStack.getItem() instanceof LoomPatternItem) {
+		if (!patternStack.isEmpty() && patternStack.getItem() instanceof LoomPatternProvider) {
 			boolean overfull = BannerBlockEntity.getPatternCount(banner) >= patternLimit;
 
 			if (!overfull) {
-				LoomPattern pattern = ((LoomPatternItem) patternStack.getItem()).getPattern();
+				LoomPattern pattern = ((LoomPatternProvider) patternStack.getItem()).getPattern();
 				this.selectedPattern.set(-LoomPatternsInternal.getLoomIndex(pattern) - (1 + BannerPattern.LOOM_APPLICABLE_COUNT));
 			} else {
 				this.selectedPattern.set(0);
@@ -248,7 +248,7 @@ public abstract class LoomContainerMixin extends ScreenHandler {
 	private void attemptBppPatternItemTransfer(PlayerEntity player, int slotIdx, CallbackInfoReturnable<ItemStack> info) {
 		ItemStack stack = this.slots.get(slotIdx).getStack();
 
-		if (stack.getItem() instanceof LoomPatternItem) {
+		if (stack.getItem() instanceof LoomPatternProvider) {
 			if (!this.insertItem(stack, this.patternSlot.id, this.patternSlot.id + 1, false)) {
 				info.setReturnValue(ItemStack.EMPTY);
 			}

--- a/src/main/java/io/github/fablabsmc/fablabs/mixin/bannerpattern/LoomContainerPatternSlotMixin.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/mixin/bannerpattern/LoomContainerPatternSlotMixin.java
@@ -1,6 +1,6 @@
 package io.github.fablabsmc.fablabs.mixin.bannerpattern;
 
-import io.github.fablabsmc.fablabs.api.bannerpattern.v1.LoomPatternItem;
+import io.github.fablabsmc.fablabs.api.bannerpattern.v1.LoomPatternProvider;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -17,7 +17,7 @@ public abstract class LoomContainerPatternSlotMixin extends Slot {
 
 	@Inject(method = "canInsert(Lnet/minecraft/item/ItemStack;)Z", at = @At("RETURN"), cancellable = true)
 	private void checkBppLoomPatternItem(ItemStack stack, CallbackInfoReturnable<Boolean> info) {
-		if (stack.getItem() instanceof LoomPatternItem) {
+		if (stack.getItem() instanceof LoomPatternProvider) {
 			info.setReturnValue(true);
 		}
 	}


### PR DESCRIPTION
We might want to allow items that have other superclasses to behave as pattern items (say, a pickaxe).

This is easily done by pulling up the required behaviour (getPattern method) to an interface and checking for that instead. The existing `LoomPatternItem` stays as a convenience implementation.